### PR TITLE
Fix parameter name

### DIFF
--- a/exp/lib/api_utils.py
+++ b/exp/lib/api_utils.py
@@ -16,7 +16,7 @@ def authenticate(username, password, organization):
   payload["username"] = username
   payload["password"] = password
   payload["org"] = organization
-  response = requests.post(url, json=payload)
+  response = requests.post(url, data=payload)
   response.raise_for_status()
   body = response.json()
   return body["token"]


### PR DESCRIPTION
On Debian 8.2, Python 2.7.9 I get the below traceback.

This pull requests fixes the call to request.post()

``` python
Traceback (most recent call last):
  File "exp_example.py", line 39, in <module>
    organization="exp")
  File "/home/scala/scala/git/exp-test/src/modules/scala/exp/runtime.py", line 39, in start
    socket.start(host, port, credentials.get_token())
  File "/home/scala/scala/git/exp-test/src/modules/scala/exp/lib/credentials.py", line 50, in get_token
    _generate_token()
  File "/home/scala/scala/git/exp-test/src/modules/scala/exp/lib/credentials.py", line 57, in _generate_token
    _generate_user_token()
  File "/home/scala/scala/git/exp-test/src/modules/scala/exp/lib/credentials.py", line 66, in _generate_user_token
    _vars["token"] = api_utils.authenticate(_vars["username"], _vars["password"], _vars["organization"])
  File "/home/scala/scala/git/exp-test/src/modules/scala/exp/lib/api_utils.py", line 19, in authenticate
    response = requests.post(url, json=payload)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 88, in post
    return request('post', url, data=data, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
TypeError: request() got an unexpected keyword argument 'json'
```
